### PR TITLE
Fix for ROCANA-3464 Fix Impala's HBase after upgrading to HDP version

### DIFF
--- a/fe/src/test/resources/hbase-site.xml.template
+++ b/fe/src/test/resources/hbase-site.xml.template
@@ -50,6 +50,10 @@
     <name>hbase.rpc.timeout</name>
     <value>30000</value>
   </property>
+  <property>
+    <name>hbase.master.port</name>
+    <value>60000</value>
+  </property>
 
   <property>
     <name>hbase.zookeeper.property.dataDir</name>


### PR DESCRIPTION
Joey fixed this while he and I screen shared. HBase changed their default port from 60,000 to 16,000. See https://issues.apache.org/jira/browse/HBASE-10123

It seems that change was made before v1.0 even though the previous version of HBase that Impala was using was version 1.0.0-cdh5.4.5. So maybe Cloudera's fork still used port 60000 even though the above JIRA would have been fixed. Then, when we moved to the Hortonworks version which does not have any special Cloudera fixes, we got the change to port 16000. This all makes sense since Impala also starts KMS which runs on port 16000 as well, so Cloudera would have seen a port conflict and may have resolved it by reverting their fork of HBase to the old port 60000.

When Joey made this change he had to add the same XML to fe/src/test/resources/hbase-site.xml, which is not stored in git.
