### PR TITLE
ROCANA-3545: Add generated Impala files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ org.eclipse.jdt.ui.prefs
 load-*-generated.sql
 bin/version.info
 
+# ROCANA-3545
+compile_commands.json
+fe/src/test/resources/hive-log4j.properties
+fe/src/test/resources/sentry-site.xml
+
 pprof.out
 
 TempStatsStore


### PR DESCRIPTION
This adds a few files generated by buildall.sh to .gitignore so we don't have to see them when running `git status`, nor do we have to worry about accidentally adding them to git.
