### PR TITLE
ROCANA-3570: Impala pulls in jars that become broken symlinks

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -87,6 +87,14 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <!-- ROCANA-3570 This is an HDP-only dependency we don't need. -->
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+          <!-- We're specifically excluding classifier = tests, but it's illegal to specify <classifier> here -->
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -257,6 +265,13 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-shims</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <!-- ROCANA-3570 This is an HDP-only dependency we don't need -->
+        <exclusion>
+          <groupId>org.apache.hive.shims</groupId>
+          <artifactId>hive-shims-0.20S</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
Our HDP version of Impala was pulling in two extra jars that the Cloudera version did not pull in. These came in from HDP versions of components we were using. The problem is the cdh-package project that creates our Impala RPM (for HDP) found these two jars and generated broken symlinks for them. This commit excludes those two jars so we won't have the broken symlinks anymore.

I did a `mvn clean package` to test and it still builds fine.

I used `mvn dependency:tree` to see how the jars were pulled in and to make sure they were totally gone afterwards. After this commit the only thing that changed in the dependency tree is those two jars were missing, which is exactly what we wanted.

Here are the full coordinates of the jars removed:
- org.apache.zookeeper:zookeeper:test-jar:tests:3.4.6.2.3.0.0-2557:compile
- org.apache.hive.shims:hive-shims-0.20S:jar:1.2.1.2.3.0.0-2557:runtime

`mvn dependency:tree` output (note: I removed some lines before and after the tree which weren't necesarry)
- [before.txt](https://github.com/scalingdata/Impala/files/9520/before.txt)
- [after.txt](https://github.com/scalingdata/Impala/files/9521/after.txt)
