### PR TITLE
ROCANA-3610: Set final Impala version number

### DIFF
--- a/bin/save-version.sh
+++ b/bin/save-version.sh
@@ -17,7 +17,7 @@
 # Note: for internal (aka pre-release) versions, the version should have
 # "-INTERNAL" appended. Parts of the code will look for this to distinguish
 # between released and internal versions.
-VERSION=2.2.0-hdp2.3.0-rocana1.3.0-rc1
+VERSION=2.2.0-hdp2.3.0-rocana1.3.0
 GIT_HASH=$(git rev-parse HEAD)
 BUILD_TIME=`date`
 HEADER="# Generated version information from save-version.sh"


### PR DESCRIPTION
Remove the `-rc1` from Impala build's version number, in preparation for Rocana Ops 1.3.0
