### PR TITLE
ROCANA-4170: Impala does not compile on CentOS 7 due to Berkeley DB 5.x

### DIFF
--- a/thirdparty/cyrus-sasl-2.1.23/sasldb/db_berkeley.c
+++ b/thirdparty/cyrus-sasl-2.1.23/sasldb/db_berkeley.c
@@ -100,7 +100,7 @@ static int berkeleydb_open(const sasl_utils_t *utils,
     ret = db_create(mbdb, NULL, 0);
     if (ret == 0 && *mbdb != NULL)
     {
-#if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 1
+#if (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 1) || DB_VERSION_MAJOR >= 5
 	ret = (*mbdb)->open(*mbdb, NULL, path, NULL, DB_HASH, flags, 0660);
 #else
 	ret = (*mbdb)->open(*mbdb, path, NULL, DB_HASH, flags, 0660);

--- a/thirdparty/cyrus-sasl-2.1.23/utils/dbconverter-2.c
+++ b/thirdparty/cyrus-sasl-2.1.23/utils/dbconverter-2.c
@@ -214,7 +214,7 @@ static int berkeleydb_open(const char *path,DB **mbdb)
     ret = db_create(mbdb, NULL, 0);
     if (ret == 0 && *mbdb != NULL)
     {
-#if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 1
+#if (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 1) || DB_VERSION_MAJOR >= 5
 	ret = (*mbdb)->open(*mbdb, NULL, path, NULL, DB_HASH, DB_CREATE, 0664);
 #else
 	ret = (*mbdb)->open(*mbdb, path, NULL, DB_HASH, DB_CREATE, 0664);


### PR DESCRIPTION
I had two options to fix this:
1. Change the preprocessor code so it treats 5.0 the same as 4.1. The current code says "if 4.1, 4.2, 4.3 etc. then use the new function definition, else use the old one", but that doesn't work when the major
   version increases. We can modify the code so it says "if 4.1, 4.2, 4.3 etc. or >= 5 then use the new function definition".
2. Use Berkeley DB 4, which also comes on CentOS 7 (see /usr/include/libdb4/db.h, which is version 4.8.30). We'd have to change the Impala build process to compile/link against Berkeley DB 4

I went with `#1` in this commit. `#2` seemed like a harder fix. Plus, I wasn't sure what would happen if we ran it on a CentOS 7 machine that had Berkeley DB 5 as the default.
